### PR TITLE
Decode location.href to get consistent results on Firefox

### DIFF
--- a/url.js
+++ b/url.js
@@ -4,7 +4,7 @@ window.url = (function() {
     }
     
     return function(arg, url) {
-        var _ls = url || window.location.toString();
+        var _ls = url || window.decodeURI(window.location.toString());
 
         if (!arg) { return _ls; }
         else { arg = arg.toString(); }


### PR DESCRIPTION
window.location.toString() in Firefox returns the encoded version of the url. Example:

Firefox: http://www.example.com/?foo%5B1%5D=bar
Other browsers: http://www.example.com/?foo[1]=bar