### PR TITLE
Add support for array of values

### DIFF
--- a/url.js
+++ b/url.js
@@ -60,11 +60,18 @@ window.url = (function() {
 
             arg = arg.substring(1);
             params = params.split('&');
+            result = [];
 
             for(var i=0,ii=params.length; i<ii; i++)
             {
                 param = params[i].split('=');
-                if(param[0] === arg) { return param[1] || ''; }
+                if(param[0] === arg) { result.push(param[1] || ''); }
+            }
+
+            if (result.length == 1) {
+                return result[0];
+            } else if (result.length > 1) {
+                return result;
             }
 
             return null;


### PR DESCRIPTION
Found your library while trying to extract parameter from the URI, though eventually I needed to support multiple values for the same parameter (bugzilla uses one hidden input for each bug_id when invoking a CGI script to export bugs). This patch keeps with your existing API:
* Param not found: return undefined
* Param found but no value: return empty string
* Param found, 1 value: return value

And one new case:
* Param found, N values: return array of values