### PR TITLE
use for loop instead of for in loop for array

### DIFF
--- a/url.js
+++ b/url.js
@@ -27,7 +27,7 @@ window.url = (function() {
             tmp = [],
             arg2 = arg.substring(1);
 
-        for (var i in split) {
+        for (var i = 0; i < split.length; i++) {
             field = split[i].match(/(.*?)=(.*)/);
 
             // TODO: regex should be able to handle this.


### PR DESCRIPTION
This prevents problems with code that extends the prototype of arrays. 
http://stackoverflow.com/questions/500504/why-is-using-for-in-with-array-iteration-such-a-bad-idea
